### PR TITLE
'attack' causes fork bomb in Windows

### DIFF
--- a/bees
+++ b/bees
@@ -2,4 +2,5 @@
 
 from beeswithmachineguns import main
 
-main.main()
+if __name__ == '__main__':
+    main.main()


### PR DESCRIPTION
The multiprocessing library needs special treatment in Windows, otherwise it causes a fork bomb. This is a known issue.
Bug description: http://bugs.python.org/issue6147

The best fix seems to be to wrap the main entry point in a **name** == '**main**' check.
Fix description: http://docs.python.org/library/multiprocessing.html#windows

With this fix (and renaming bees to bees.py in my Scripts folder) I can happily cause destruction.
