### PR TITLE
Quicker recognition of instances that are up

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -108,6 +108,7 @@ def up(count, group, zone, image_id, username, key_name):
     instance_ids = []
 
     for instance in reservation.instances:
+        instance.update()
         while instance.state != 'running':
             print '.'
             time.sleep(5)


### PR DESCRIPTION
As there is a delay of 5 seconds between each check of instance state, when launching lots of instances there is an obligatory pause of 5 seconds between each instance going up.  Updating the instance state before each check speeds up the launching of lots of instances
