### PR TITLE
Allow specifying EC2 instance types besides t1.micro

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -34,7 +34,6 @@ import urllib2
 import boto
 import paramiko
 
-EC2_INSTANCE_TYPE = 't1.micro'
 STATE_FILENAME = os.path.expanduser('~/.bees')
 
 # Utilities
@@ -69,7 +68,7 @@ def _get_pem_path(key):
 
 # Methods
 
-def up(count, group, zone, image_id, username, key_name):
+def up(count, group, zone, image_id, instance_type, username, key_name):
     """
     Startup the load testing server.
     """
@@ -99,7 +98,7 @@ def up(count, group, zone, image_id, username, key_name):
         max_count=count,
         key_name=key_name,
         security_groups=[group],
-        instance_type=EC2_INSTANCE_TYPE,
+        instance_type=instance_type,
         placement=zone)
 
     print 'Waiting for bees to load their machine guns...'

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -68,6 +68,9 @@ commands:
     up_group.add_option('-i', '--instance',  metavar="INSTANCE",  nargs=1,
                         action='store', dest='instance', type='string', default='ami-ff17fb96',
                         help="The instance-id to use for each server from (default: ami-ff17fb96).")
+    up_group.add_option('-t', '--type',  metavar="TYPE",  nargs=1,
+                        action='store', dest='type', type='string', default='t1.micro',
+                        help="The instance-type to use for each server (default: t1.micro).")
     up_group.add_option('-l', '--login',  metavar="LOGIN",  nargs=1,
                         action='store', dest='login', type='string', default='newsapps',
                         help="The ssh username name to use to connect to the new servers (default: newsapps).")
@@ -105,7 +108,7 @@ commands:
         if options.group == 'default':
             print 'New bees will use the "default" EC2 security group. Please note that port 22 (SSH) is not normally open on this group. You will need to use to the EC2 tools to open it before you will be able to attack.'
 
-        bees.up(options.servers, options.group, options.zone, options.instance, options.login, options.key)
+        bees.up(options.servers, options.group, options.zone, options.instance, options.type, options.login, options.key)
     elif command == 'attack':
         if not options.url:
             parser.error('To run an attack you need to specify a url with -u')


### PR DESCRIPTION
(See original Issue #7)

Micro instances are intended for "bursty" activity and will be limited in non-specific ways by Amazon. Since many load-test tools (like ab) use lots of CPU, this can prevent getting accurate load testing results.

This commit adds support for overriding the default `t1.micro` instance via a command-line arg.
