### PR TITLE
VPC Support

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -71,6 +71,19 @@ def _get_pem_path(key):
 
 def _get_region(zone):
     return zone[:-1] # chop off the "d" in the "us-east-1d" to get the "Region"
+	
+def _get_security_group_ids(connection, security_group_names):
+	ids = []
+	# Since we cannot get security groups in a vpc by name, we get all security groups and parse them by name later
+	security_groups = connection.get_all_security_groups()
+	
+	# Parse the name of each security group and add the id of any match to the group list
+	for group in security_groups:
+		for name in security_group_names:
+			if group.name == name:
+				ids.append(group.id)
+		
+	return ids
 
 # Methods
 
@@ -98,25 +111,15 @@ def up(count, group, zone, image_id, instance_type, username, key_name, subnet):
 
     print 'Attempting to call up %i bees.' % count
 
-    if not subnet:
-        reservation = ec2_connection.run_instances(
-            image_id=image_id,
-            min_count=count,
-            max_count=count,
-            key_name=key_name,
-            security_groups=[group],
-            instance_type=instance_type,
-            placement=zone)
-    else:
-        reservation = ec2_connection.run_instances(
-            image_id=image_id,
-            min_count=count,
-            max_count=count,
-            key_name=key_name,
-            security_group_ids=[group],
-            instance_type=instance_type,
-            placement=zone,
-		    subnet_id=subnet)
+    reservation = ec2_connection.run_instances(
+        image_id=image_id,
+        min_count=count,
+        max_count=count,
+        key_name=key_name,
+        security_group_ids=_get_security_group_ids(ec2_connection, [group]),
+        instance_type=instance_type,
+        placement=zone,
+		subnet_id=subnet)
 
     print 'Waiting for bees to load their machine guns...'
 

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -61,7 +61,7 @@ commands:
                         help="The number of servers to start (default: 5).")
     up_group.add_option('-g', '--group', metavar="GROUP", nargs=1,
                         action='store', dest='group', type='string', default='default',
-                        help="The security group to run the instances under. If a vpc subnet is specified using the -v parameter, you must specify security group id's instead of names (default: default).")
+                        help="The security group(s) to run the instances under (default: default).")
     up_group.add_option('-z', '--zone',  metavar="ZONE",  nargs=1,
                         action='store', dest='zone', type='string', default='us-east-1d',
                         help="The availability zone to start the instances in (default: us-east-1d).")
@@ -76,7 +76,7 @@ commands:
                         help="The ssh username name to use to connect to the new servers (default: newsapps).")
     up_group.add_option('-v', '--subnet',  metavar="SUBNET",  nargs=1,
                         action='store', dest='subnet', type='string', default=None,
-                        help="The vpc subnet id in which the instances should be launched. When using this option, you must specify at least one security group id using the -g parameter (default: None).")
+                        help="The vpc subnet id in which the instances should be launched. (default: None).")
 
     parser.add_option_group(up_group)
 


### PR DESCRIPTION
I needed vpc support for a project I was working on so I went ahead and added it. Thought it might be useful to others.

Note that this change introduces parameter dependencies when using a vpc subnet in
that security group identifiers must be passed as ID's instead of names,
and at least one security group is required in order to create an
instance in a vpc subnet. The documentation may need to be updated accordingly.
