### PR TITLE
-a/--keep-alive argument to bees attack

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -229,6 +229,8 @@ def _attack(params):
             pem_file_path=_get_pem_path(params['key_name'])
             os.system("scp -q -o 'StrictHostKeyChecking=no' -i %s %s %s@%s:/tmp/honeycomb" % (pem_file_path, params['post_file'], params['username'], params['instance_name']))
             options += ' -k -T "%(mime_type)s; charset=UTF-8" -p /tmp/honeycomb' % params
+        elif params.get('keep_alive'):
+            options += ' -k'
 
         params['options'] = options
         benchmark_command = 'ab -r -n %(num_requests)s -c %(concurrent_requests)s -C "sessionid=NotARealSessionID" %(options)s "%(url)s"' % params
@@ -418,6 +420,7 @@ def attack(url, n, c, **options):
             'headers': headers,
             'post_file': options.get('post_file'),
             'mime_type': options.get('mime_type', ''),
+            'keep_alive': options.get('keep_alive', False)
         })
 
     print 'Stinging URL so it will be cached for the attack.'

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -105,6 +105,9 @@ commands:
     attack_group.add_option('-e', '--csv', metavar="FILENAME", nargs=1,
                         action='store', dest='csv_filename', type='string', default='',
                         help="Store the distribution of results in a csv file for all completed bees (default: '').")
+    attack_group.add_option('-a', '--keep-alive', metavar="KEEP_ALIVE",
+                        action='store_true', dest='keep_alive', default=False,
+                        help="Enable the HTTP KeepAlive feature, i.e., perform multiple requests within one HTTP session.")
 
     parser.add_option_group(attack_group)
 
@@ -139,6 +142,7 @@ commands:
             post_file=options.post_file,
             mime_type=options.mime_type,
             csv_filename=options.csv_filename,
+            keep_alive=options.keep_alive
         )
 
         bees.attack(options.url, options.number, options.concurrent, **additional_options)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='beeswithmachineguns',
-      version='0.1.4',
+      version='0.1.5',
       description='A utility for arming (creating) many bees (micro EC2 instances) to attack (load test) targets (web applications).',
       author='Christopher Groskopf',
       author_email='cgroskopf@tribune.com',


### PR DESCRIPTION
bees attack now takes additional argument -a (or --keep-alive) to keep the connections alive. By default set to false.
