### PR TITLE
Use mktemp instead of tempfile to work on centos

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -220,7 +220,7 @@ def _attack(params):
                 if h != '':
                     options += ' -H "%s"' % h.strip()
 
-        stdin, stdout, stderr = client.exec_command('tempfile -s .csv')
+        stdin, stdout, stderr = client.exec_command('mktemp -t XXXXX.csv')
         params['csv_filename'] = stdout.read().strip()
         if params['csv_filename']:
             options += ' -e %(csv_filename)s' % params


### PR DESCRIPTION
From tempfile man page

BUGS
Exclusive creation is not guaranteed when creating files on NFS parti‐
tions.  tempfile is deprecated; you should use mktemp(1) instead.
