### PR TITLE
Update bees.py

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -474,7 +474,7 @@ def attack(url, n, c, **options):
         params.append({
             'i': i,
             'instance_id': instance.id,
-            'instance_name': instance.public_dns_name,
+            'instance_name': instance.private_dns_name if instance.public_dns_name == "" else instance.public_dns_name,
             'url': url,
             'concurrent_requests': connections_per_instance,
             'num_requests': requests_per_instance,


### PR DESCRIPTION
Changed to us private dns name if it is not public facing. This allows you to run bees on a private vpc at aws.