### PR TITLE
Summarized failed requests details in the final report

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -265,6 +265,19 @@ def _attack(params):
 
         requests_per_second_search = re.search('Requests\ per\ second:\s+([0-9.]+)\ \[#\/sec\]\ \(mean\)', ab_results)
         failed_requests = re.search('Failed\ requests:\s+([0-9.]+)', ab_results)
+        response['failed_requests_connect'] = 0
+        response['failed_requests_receive'] = 0
+        response['failed_requests_length'] = 0
+        response['failed_requests_exceptions'] = 0
+        if float(failed_requests.group(1)) > 0:
+            failed_requests_detail = re.search('(Connect: [0-9.]+, Receive: [0-9.]+, Length: [0-9.]+, Exceptions: [0-9.]+)', ab_results)
+            if failed_requests_detail:
+                response['failed_requests_connect'] = float(re.search('Connect:\s+([0-9.]+)', failed_requests_detail.group(0)).group(1))
+                response['failed_requests_receive'] = float(re.search('Receive:\s+([0-9.]+)', failed_requests_detail.group(0)).group(1))
+                response['failed_requests_length'] = float(re.search('Length:\s+([0-9.]+)', failed_requests_detail.group(0)).group(1))
+            response['failed_requests_exceptions'] = float(re.search('Exceptions:\s+([0-9.]+)', failed_requests_detail.group(0)).group(1))
+
+        
         complete_requests_search = re.search('Complete\ requests:\s+([0-9]+)', ab_results)
 
         response['ms_per_request'] = float(ms_per_request_search.group(1))
@@ -307,6 +320,18 @@ def _summarize_results(results, params, csv_filename):
 
     complete_results = [r['failed_requests'] for r in summarized_results['complete_bees']]
     summarized_results['total_failed_requests'] = sum(complete_results)
+
+    complete_results = [r['failed_requests_connect'] for r in summarized_results['complete_bees']]
+    summarized_results['total_failed_requests_connect'] = sum(complete_results)
+
+    complete_results = [r['failed_requests_receive'] for r in summarized_results['complete_bees']]
+    summarized_results['total_failed_requests_receive'] = sum(complete_results)
+
+    complete_results = [r['failed_requests_length'] for r in summarized_results['complete_bees']]
+    summarized_results['total_failed_requests_length'] = sum(complete_results)
+
+    complete_results = [r['failed_requests_exceptions'] for r in summarized_results['complete_bees']]
+    summarized_results['total_failed_requests_exceptions'] = sum(complete_results)
 
     complete_results = [r['requests_per_second'] for r in summarized_results['complete_bees']]
     summarized_results['mean_requests'] = sum(complete_results)
@@ -389,7 +414,10 @@ def _print_results(summarized_results):
     print '     Complete requests:\t\t%i' % summarized_results['total_complete_requests']
 
     print '     Failed requests:\t\t%i' % summarized_results['total_failed_requests']
-
+    print '          connect:\t\t%i' % summarized_results['total_failed_requests_connect']
+    print '          receive:\t\t%i' % summarized_results['total_failed_requests_receive']
+    print '          length:\t\t%i' % summarized_results['total_failed_requests_length']
+    print '          exceptions:\t\t%i' % summarized_results['total_failed_requests_exceptions']
     print '     Requests per second:\t%f [#/sec] (mean of bees)' % summarized_results['mean_requests']
     if 'rps_bounds' in summarized_results and summarized_results['rps_bounds'] is not None:
         print '     Requests per second:\t%f [#/sec] (upper bounds)' % summarized_results['rps_bounds']

--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -275,7 +275,7 @@ def _attack(params):
                 response['failed_requests_connect'] = float(re.search('Connect:\s+([0-9.]+)', failed_requests_detail.group(0)).group(1))
                 response['failed_requests_receive'] = float(re.search('Receive:\s+([0-9.]+)', failed_requests_detail.group(0)).group(1))
                 response['failed_requests_length'] = float(re.search('Length:\s+([0-9.]+)', failed_requests_detail.group(0)).group(1))
-            response['failed_requests_exceptions'] = float(re.search('Exceptions:\s+([0-9.]+)', failed_requests_detail.group(0)).group(1))
+                response['failed_requests_exceptions'] = float(re.search('Exceptions:\s+([0-9.]+)', failed_requests_detail.group(0)).group(1))
 
         
         complete_requests_search = re.search('Complete\ requests:\s+([0-9]+)', ab_results)


### PR DESCRIPTION
In ab (Apache Benchmark) response when there are some failed requests, it also return information about errors details. Requests can be considered failed for different conditions: connect, exception, length, etc...
I summarized in the final report the details about failed requests.
This can be usefull because some times length errors can be ignored and if you haven't got any information about the reason the requests failed it's difficult to know if the test is ok or not.