### PR TITLE
Removed need for trailing slash on root domains

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -68,8 +68,6 @@ This spins up 4 servers in security group 'public' using the EC2 keypair 'frakki
 
 *Note*: the default EC2 security group is called 'default' and by default it locks out SSH access. I recommend creating a 'public' security group for use with the bees and explicitly opening port 22 on that group.
 
-*Note 2*: Always include a trailing slash when testing a root domain. The underlying load-testing tool (ab) doesn't support raw domains.
-
 It then uses those 4 servers to send 10,000 requests, 250 at a time, to attack OurNewWebbyHotness.com.
 
 Lastly, it spins down the 4 servers.  *Please remember to do this*--we aren't responsible for your EC2 bills.

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -145,6 +145,8 @@ commands:
                 parsed = urlparse("http://" + options.url + "/")
             else:
                 parsed = urlparse(options.url + "/")
+        if not parsed.scheme:
+                parsed = urlparse("http://" + options.url + "/")
         additional_options = dict(
             cookies=options.cookies,
             headers=options.headers,

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -146,7 +146,7 @@ commands:
             else:
                 parsed = urlparse(options.url + "/")
         if not parsed.scheme:
-                parsed = urlparse("http://" + options.url + "/")
+                parsed = urlparse("http://" + options.url)
         additional_options = dict(
             cookies=options.cookies,
             headers=options.headers,

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -140,12 +140,11 @@ commands:
             parser.error('To run an attack you need to specify a url with -u')
 
         parsed = urlparse(options.url)
-        if not parsed.scheme:
-            parsed = urlparse("http://" + options.url)
-
-        if not parsed.path:
-            parser.error('It appears your URL lacks a trailing slash, this will disorient the bees. Please try again with a trailing slash.')
-
+        if "/" not in parsed.path:
+            if not parsed.scheme:
+                parsed = urlparse("http://" + options.url + "/")
+            else:
+                parsed = urlparse(options.url + "/")
         additional_options = dict(
             cookies=options.cookies,
             headers=options.headers,


### PR DESCRIPTION
This program used to require that users included a trailing slash on root domains. It no longer requires that. 