### PR TITLE
Support for spot instances with the -b command line option

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -29,6 +29,7 @@ import os
 import re
 import socket
 import time
+import urllib
 import urllib2
 import base64
 import csv
@@ -54,7 +55,7 @@ def _read_server_list():
         key_name = f.readline().strip()
         zone = f.readline().strip()
         text = f.read()
-        instance_ids = text.split('\n')
+        instance_ids = [i for i in text.split('\n') if i != '']
 
         print 'Read %i bees from the roster.' % len(instance_ids)
 
@@ -129,6 +130,9 @@ def up(count, group, zone, image_id, instance_type, username, key_name, subnet, 
             instance_type=instance_type,
             placement=None if 'gov' in zone else zone,
             subnet_id=subnet)
+
+        # it can take a few seconds before the spot requests are fully processed
+        time.sleep(5)
 
         instances = _wait_for_spot_request_fulfillment(ec2_connection, spot_requests)
     else:
@@ -280,7 +284,7 @@ def _attack(params):
             options += ' -k'
 
         if params['cookies'] is not '':
-            options += ' -H \"Cookie: %ssessionid=NotARealSessionID;\"' % params['cookies']
+            options += ' -H \"Cookie: %s;sessionid=NotARealSessionID;\"' % params['cookies']
         else:
             options += ' -C \"sessionid=NotARealSessionID\"'
 

--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -33,7 +33,6 @@ import urllib2
 import base64
 import csv
 import sys
-import math
 import random
 
 import boto
@@ -96,7 +95,7 @@ def _get_security_group_ids(connection, security_group_names, subnet):
 
 # Methods
 
-def up(count, group, zone, image_id, instance_type, username, key_name, subnet):
+def up(count, group, zone, image_id, instance_type, username, key_name, subnet, bid = None):
     """
     Startup the load testing server.
     """
@@ -118,23 +117,40 @@ def up(count, group, zone, image_id, instance_type, username, key_name, subnet):
 
     ec2_connection = boto.ec2.connect_to_region(_get_region(zone))
 
-    print 'Attempting to call up %i bees.' % count
+    if bid:
+        print 'Attempting to call up %i spot bees, this can take a while...' % count
 
-    reservation = ec2_connection.run_instances(
-        image_id=image_id,
-        min_count=count,
-        max_count=count,
-        key_name=key_name,
-        security_groups=[group] if subnet is None else _get_security_group_ids(ec2_connection, [group], subnet),
-        instance_type=instance_type,
-        placement=None if 'gov' in zone else zone,
-        subnet_id=subnet)
+        spot_requests = ec2_connection.request_spot_instances(
+            image_id=image_id,
+            price=bid,
+            count=count,
+            key_name=key_name,
+            security_groups=[group] if subnet is None else _get_security_group_ids(ec2_connection, [group], subnet),
+            instance_type=instance_type,
+            placement=None if 'gov' in zone else zone,
+            subnet_id=subnet)
+
+        instances = _wait_for_spot_request_fulfillment(ec2_connection, spot_requests)
+    else:
+        print 'Attempting to call up %i bees.' % count
+
+        reservation = ec2_connection.run_instances(
+            image_id=image_id,
+            min_count=count,
+            max_count=count,
+            key_name=key_name,
+            security_groups=[group] if subnet is None else _get_security_group_ids(ec2_connection, [group], subnet),
+            instance_type=instance_type,
+            placement=None if 'gov' in zone else zone,
+            subnet_id=subnet)
+
+        instances = reservation.instances
 
     print 'Waiting for bees to load their machine guns...'
 
     instance_ids = []
 
-    for instance in reservation.instances:
+    for instance in instances:
         instance.update()
         while instance.state != 'running':
             print '.'
@@ -147,9 +163,9 @@ def up(count, group, zone, image_id, instance_type, username, key_name, subnet):
 
     ec2_connection.create_tags(instance_ids, { "Name": "a bee!" })
 
-    _write_server_list(username, key_name, zone, reservation.instances)
+    _write_server_list(username, key_name, zone, instances)
 
-    print 'The swarm has assembled %i bees.' % len(reservation.instances)
+    print 'The swarm has assembled %i bees.' % len(instances)
 
 def report():
     """
@@ -195,6 +211,27 @@ def down():
     print 'Stood down %i bees.' % len(terminated_instance_ids)
 
     _delete_server_list()
+
+def _wait_for_spot_request_fulfillment(conn, requests, fulfilled_requests = []):
+    """
+    Wait until all spot requests are fulfilled.
+
+    Once all spot requests are fulfilled, return a list of corresponding spot instances.
+    """
+    if len(requests) == 0:
+        reservations = conn.get_all_instances(instance_ids = [r.instance_id for r in fulfilled_requests])
+        return [r.instances[0] for r in reservations]
+    else:
+        time.sleep(10)
+        print '.'
+
+    requests = conn.get_all_spot_instance_requests(request_ids=[req.id for req in requests])
+    for req in requests:
+        if req.status.code == 'fulfilled':
+            fulfilled_requests.append(req)
+            print "spot bee `{}` joined the swarm.".format(req.instance_id)
+
+    return _wait_for_spot_request_fulfillment(conn, [r for r in requests if r not in fulfilled_requests], fulfilled_requests)
 
 def _attack(params):
     """

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -76,6 +76,9 @@ commands:
     up_group.add_option('-v', '--subnet',  metavar="SUBNET",  nargs=1,
                         action='store', dest='subnet', type='string', default=None,
                         help="The vpc subnet id in which the instances should be launched. (default: None).")
+    up_group.add_option('-b', '--bid', metavar="BID", nargs=1,
+                        action='store', dest='bid', type='float', default=None,
+                        help="The maximum bid price per spot instance (default: None).")
 
     parser.add_option_group(up_group)
 
@@ -134,7 +137,8 @@ commands:
 
         if options.group == 'default':
             print 'New bees will use the "default" EC2 security group. Please note that port 22 (SSH) is not normally open on this group. You will need to use to the EC2 tools to open it before you will be able to attack.'
-        bees.up(options.servers, options.group, options.zone, options.instance, options.type, options.login, options.key, options.subnet)
+
+        bees.up(options.servers, options.group, options.zone, options.instance, options.type, options.login, options.key, options.subnet, options.bid)
     elif command == 'attack':
         if not options.url:
             parser.error('To run an attack you need to specify a url with -u')
@@ -164,7 +168,6 @@ commands:
         bees.down()
     elif command == 'report':
         bees.report()
-
 
 def main():
     parse_options()


### PR DESCRIPTION
This pull request implements support for launching bees on spot instances. Specify the -b flag followed by your bid price. Once the bees are up, everything works as usual. 