### PR TITLE
Turn off default cert verification in attack function

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -35,6 +35,7 @@ import base64
 import csv
 import sys
 import random
+import ssl
 
 import boto
 import boto.ec2
@@ -591,7 +592,8 @@ def attack(url, n, c, **options):
     for key, value in dict_headers.iteritems():
         request.add_header(key, value)
 
-    response = urllib2.urlopen(request)
+    context = ssl._create_unverified_context()
+    response = urllib2.urlopen(request, context=context)
     response.read()
 
     print 'Organizing the swarm.'


### PR DESCRIPTION
Starting in 2.7.9, urllib and urllib2 have certificate verification enabled by default. If the target server uses a self-signed cert, ```attack``` raises a URLError. This PR provides the context argument to ```urllib2.urlopen``` to disable certificate verification.

See https://www.python.org/dev/peps/pep-0476/