### PR TITLE
Handle differences between state file values and flag parameters

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -105,7 +105,7 @@ def up(count, group, zone, image_id, instance_type, username, key_name, subnet, 
     existing_username, existing_key_name, existing_zone, instance_ids = _read_server_list()
 
     count = int(count)
-    if instance_ids and existing_username == username and existing_key_name == key_name and existing_zone == zone:
+    if existing_username == username and existing_key_name == key_name and existing_zone == zone:
         # User, key and zone match existing values and instance ids are found on state file
         if count <= len(instance_ids):
             # Count is less than the amount of existing instances. No need to create new ones.

--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -106,14 +106,21 @@ def up(count, group, zone, image_id, instance_type, username, key_name, subnet, 
 
     count = int(count)
     if instance_ids and existing_username == username and existing_key_name == key_name and existing_zone == zone:
+        # User, key and zone match existing values and instance ids are found on state file
         if count <= len(instance_ids):
+            # Count is less than the amount of existing instances. No need to create new ones.
             print 'Bees are already assembled and awaiting orders.'
             return
         else:
+            # Count is greater than the amount of existing instances. Need to create the only the extra instances.
             count -= len(instance_ids)
     elif instance_ids:
+        # Instances found on state file but user, key and/or zone not matching existing value.
+        # State file only stores one user/key/zone config combination so instances are unusable.
         print 'Taking down {} unusable bees.'.format(len(instance_ids))
+        # Redirect prints in down() to devnull to avoid duplicate messages
         _redirect_stdout('/dev/null', down)
+        # down() deletes existing state file so _read_server_list() returns a blank state
         existing_username, existing_key_name, existing_zone, instance_ids = _read_server_list()
 
     pem_path = _get_pem_path(key_name)

--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -112,8 +112,9 @@ def up(count, group, zone, image_id, instance_type, username, key_name, subnet, 
         else:
             count -= len(instance_ids)
     elif instance_ids:
-        print 'Found {} unusable bees.'
-        down()
+        print 'Taking down {} unusable bees.'.format(len(instance_ids))
+        _redirect_stdout('/dev/null', down)
+        existing_username, existing_key_name, existing_zone, instance_ids = _read_server_list()
 
     pem_path = _get_pem_path(key_name)
 
@@ -644,3 +645,9 @@ def attack(url, n, c, **options):
             print('Your targets performance tests meet our standards, the Queen sends her regards.')
             sys.exit(0)
 
+def _redirect_stdout(outfile, func, *args, **kwargs):
+    save_out = sys.stdout
+    with open(outfile, 'w') as redir_out:
+        sys.stdout = redir_out
+        func(*args, **kwargs)
+    sys.stdout = save_out


### PR DESCRIPTION
Addresses https://github.com/newsapps/beeswithmachineguns/issues/125.

Currently the ```bees up``` command exits immediately if a ~/.bees file is found with 1 or more instance_ids. This PR fixes two workflows in particular. First, when any one of the existing username, key_name, and zone values in the state file is different from the flag parameter passed in, ```bees.down``` is now called to terminate the saved instances and delete the state file so the new instances can be created. This allows ```bees up``` to be run multiple times with different parameters without having to call ```bees down``` in between. Second, if the existing username, key_name, and zone values all match the params, ```bees up``` reuses the existing instances and only creates additional instances if the servers param is greater than the number of existing instances. If servers is less than the number of existing instances, it does nothing. This can be further improved by checking that saved instances are still available to avoid using ones terminated manually.