### PR TITLE
Add a trailing slash to root urls

### DIFF
--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -143,14 +143,11 @@ commands:
         if not options.url:
             parser.error('To run an attack you need to specify a url with -u')
 
-        parsed = urlparse(options.url)
-        if "/" not in parsed.path:
-            if not parsed.scheme:
-                parsed = urlparse("http://" + options.url + "/")
-            else:
-                parsed = urlparse(options.url + "/")
-        if not parsed.scheme:
-                parsed = urlparse("http://" + options.url)
+        # urlparse needs a scheme in the url. ab doesn't, so add one just for the sake of parsing.
+        # urlparse('google.com').path == 'google.com' and urlparse('google.com').netloc == '' -> True
+        parsed = urlparse(options.url) if '://' in options.url else urlparse('http://'+options.url)
+        if parsed.path == '':
+            options.url += '/'
         additional_options = dict(
             cookies=options.cookies,
             headers=options.headers,
@@ -164,7 +161,6 @@ commands:
         )
 
         bees.attack(options.url, options.number, options.concurrent, **additional_options)
-
     elif command == 'down':
         bees.down()
     elif command == 'report':


### PR DESCRIPTION
Fixes https://github.com/newsapps/beeswithmachineguns/issues/91, and https://github.com/newsapps/beeswithmachineguns/issues/87.

PR https://github.com/newsapps/beeswithmachineguns/pull/104 added some logic to handle this but didn't actually pass the modified url to ```bees.attack```. This PR cleans up the logic to check if a '/' should be added and uses the modified url.