### PR TITLE
Add a new command to run an setup script on each instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build
 MANIFEST
 dist
 env
+reports
+attack
+log

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -82,6 +82,14 @@ commands:
 
     parser.add_option_group(up_group)
 
+    init_group = OptionGroup(parser, 'init',
+                             """To run an init script on each instance, set the -I flag as a path to the local file.""")
+
+    init_group.add_option('-I', '--init_file', metavar='init_file', nargs=1, action='store', dest='init_file',
+                        default='', type='string', help='Init script to run on each instance after launching.')
+
+    parser.add_option_group(init_group)
+
     attack_group = OptionGroup(parser, "attack",
                                """Beginning an attack requires only that you specify the -u option with the URL you wish to target.""")
 
@@ -139,6 +147,11 @@ commands:
             print 'New bees will use the "default" EC2 security group. Please note that port 22 (SSH) is not normally open on this group. You will need to use to the EC2 tools to open it before you will be able to attack.'
 
         bees.up(options.servers, options.group, options.zone, options.instance, options.type, options.login, options.key, options.subnet, options.bid)
+    elif command == 'init':
+        if not options.init_file:
+            parser.error('To initalize the instances you need to specify a init script with -I')
+        bees.init(options.init_file)
+
     elif command == 'attack':
         if not options.url:
             parser.error('To run an attack you need to specify a url with -u')

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -88,6 +88,12 @@ commands:
     init_group.add_option('-I', '--init_file', metavar='init_file', nargs=1, action='store', dest='init_file',
                         default='', type='string', help='Init script to run on each instance after launching.')
 
+    init_group.add_option('-a', '--attack_file', metavar='attack_file', nargs=1, action='store', dest='attack_file',
+                          default='', type='string', help='Init script to run on each instance after launching.')
+
+    init_group.add_option('-V', '--verbose', metavar='verbose', action='store_true', dest='verbose',
+                          help='Print output from init script after executing.')
+
     parser.add_option_group(init_group)
 
     attack_group = OptionGroup(parser, "attack",
@@ -150,7 +156,9 @@ commands:
     elif command == 'init':
         if not options.init_file:
             parser.error('To initalize the instances you need to specify a init script with -I')
-        bees.init(options.init_file)
+        # if not options.attack_file:
+        #     parser.error('To initalize the instances you need to specify a attack script with -A')
+        bees.init(options.init_file, options.attack_file, options.verbose)
 
     elif command == 'attack':
         if not options.url:

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,25 @@
+import os
+from merge_reports import merge_results
+import boto.ec2
+from beeswithmachineguns.bees import _read_server_list, _get_region, _get_pem_path
+from fabric.api import run, env, get
+
+def set_hosts():
+    username, key_name, zone, instance_ids = _read_server_list()
+    ec2_connection = boto.ec2.connect_to_region(_get_region(zone))
+    existing_reservations = ec2_connection.get_all_instances(instance_ids=instance_ids)
+    existing_instances = []
+    map(existing_instances.extend, [r.instances for r in existing_reservations])
+    env.hosts = [instance.ip_address for instance in existing_instances]
+    env.user = username
+    env.key_filename = _get_pem_path(key_name)
+
+def runinit():
+    run('/tmp/init.sh')
+
+def runbench():
+    run('cd /tmp && make bench')
+    file = '/tmp/simple-bench.xml'
+    get(file, env.host_string+'-simple-bench.xml')
+    merge_results()
+    os.system('fl-build-report --html results.xml')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto==2.27.0
-paramiko==1.14.0
-
+paramiko==1.15.2
+Fabric==1.10.2


### PR DESCRIPTION
Adds a new command ```bees init``` to handle any setup that needs to be done on an instance. This is an optional command and doesn't change any existing uses. A setup file is specified with the -I flag on the init command, which gets pushed up to each instance then run. A trivial usage for this is to install ab when using an image it doesn't come preinstalled on, but the actual script is left up to the user. Using this command between ```bees up``` and ```bees attack``` saves the user from having to manually ssh into each instance and set them up by hand, which is especially useful when using a large number of bees.