### PR TITLE
fix invalid groupId error when not using a vpc

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,7 +1,0 @@
-{
-    "version": "0.1.0",
-    "command": "python",
-    "isShellCommand": true,
-    "showOutput": "always",
-    "args": ["${file}"]
-}

--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -157,7 +157,7 @@ def up(count, group, zone, image_id, instance_type, username, key_name, subnet, 
     if ec2_connection == None:
         raise Exception("Invalid zone specified? Unable to connect to region using zone name")
 
-    groupId = [group] if subnet is None else _get_security_group_id(ec2_connection, group, subnet)
+    groupId = group if subnet is None else _get_security_group_id(ec2_connection, group, subnet)
     print("GroupId found: %s" % groupId)
     
     placement = None if 'gov' in zone else zone


### PR DESCRIPTION
Fixes the below error
```
$ ./bees up -s 2 -g public -k bees
Connecting to the hive.
GroupId found: ['public']
Placement: us-east-1d
Attempting to call up 2 bees.
('Unable to call bees:', u'Value () for parameter groupId is invalid. The value cannot be empty')
```