### PR TITLE
Updated settings to current Amazon Linux and new-generation instance

### DIFF
--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -68,14 +68,14 @@ commands:
                         action='store', dest='zone', type='string', default='us-east-1d',
                         help="The availability zone to start the instances in (default: us-east-1d).")
     up_group.add_option('-i', '--instance',  metavar="INSTANCE",  nargs=1,
-                        action='store', dest='instance', type='string', default='ami-ff17fb96',
-                        help="The instance-id to use for each server from (default: ami-ff17fb96).")
+                        action='store', dest='instance', type='string', default='ami-08111162',
+                        help="The instance-id to use for each server from (default: ami-08111162).")
     up_group.add_option('-t', '--type',  metavar="TYPE",  nargs=1,
-                        action='store', dest='type', type='string', default='t1.micro',
-                        help="The instance-type to use for each server (default: t1.micro).")
+                        action='store', dest='type', type='string', default='t2.micro',
+                        help="The instance-type to use for each server (default: t2.micro).")
     up_group.add_option('-l', '--login',  metavar="LOGIN",  nargs=1,
-                        action='store', dest='login', type='string', default='newsapps',
-                        help="The ssh username name to use to connect to the new servers (default: newsapps).")
+                        action='store', dest='login', type='string', default='ec2-user',
+                        help="The ssh username name to use to connect to the new servers (default: ec2-user).")
     up_group.add_option('-v', '--subnet',  metavar="SUBNET",  nargs=1,
                         action='store', dest='subnet', type='string', default=None,
                         help="The vpc subnet id in which the instances should be launched. (default: None).")


### PR DESCRIPTION
The `t2` instances are a little faster and a little cheaper.
I wasn't able to find `ami-ff17fb96` when I ran `aws ec2 describe-images --owners self amazon --region us-east-1`, so I replaced it with the Amazon Linux instance for `us-east-1` (ami-08111162).
This image does _not_ have Apache Benchmark (`ab`) installed. Not sure how to resolve that across many instances, as I'm not terribly knowledgable about how to use `boto` to install packages (if it can). See issue #50 
`ec2-user` is the default user for Amazon Linux.
