### PR TITLE
Fix CSV writing on Python 2

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -499,7 +499,7 @@ def _create_request_time_cdf_csv(results, complete_bees_params, request_time_cdf
         # csv requires files in text-mode with newlines='' in python3
         # see http://python3porting.com/problems.html#csv-api-changes
         openmode = IS_PY2 and 'w' or 'wt'
-        openkwargs = IS_PY2 and {} or {'encoding': 'utf-8', 'newline': ''}
+        openkwargs = IS_PY2 and -1 or {'encoding': 'utf-8', 'newline': ''}
         with open(csv_filename, openmode, openkwargs) as stream:
             writer = csv.writer(stream)
             header = ["% faster than", "all bees [ms]"]


### PR DESCRIPTION
On Python 2 the io.open() function appears to have the signature of `io.open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None, closefd=True)`

This fix makes it so Python 2.7 works.  Unsure about 2.6 as I do not have a machine to test on.
