### PR TITLE
Bug fix: Encode basic authentication credentials for _hurl_attack()

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -998,7 +998,8 @@ def _hurl_attack(params):
             options += ' -H \"Cookie: %s;\"' % params['cookies']
 
         if params['basic_auth'] is not '':
-            options += ' -H \"Authorization : Basic %s\"' % params['basic_auth']
+            auth = base64.encodestring(params['basic_auth']).replace('\n', '')
+            options += ' -H \"Authorization : Basic %s\"' % auth
 
         if params['seconds']:
             options += ' -l %d' % params['seconds']


### PR DESCRIPTION
The basic auth credentials passed into _hurl_attack() are "user:pass".  These aren't base64 encoded before they are appended to the options for the hurl_command executed on the bees.