### PR TITLE
Fixes #110 in newsapps/beeswithmachineguns, security groups being ign…

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -207,7 +207,7 @@ def up(count, group, zone, image_id, instance_type, username, key_name, subnet, 
                 min_count=count,
                 max_count=count,
                 key_name=key_name,
-                security_group_ids=[groupId] if not subnet else None,
+                security_group_ids=[groupId],
                 instance_type=instance_type,
                 placement=placement,
                 subnet_id=subnet)


### PR DESCRIPTION
Fixes #110 in newsapps/beeswithmachineguns, security groups being ignored when -v is specified.  Removing the conditional logic on line 210 because it seems to duplicate the intention of line 178, except it defaults to None instead of looking up the sg for the appropriate subnet.  In addition this looked suspicious because line 192 for spot/bid instances does not contain such a conditional