### PR TITLE
Adds cipher suite option for newsapps/beeswithmachineguns #191, allow…

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -229,6 +229,9 @@ Options:
                         should be passed using standard cookie formatting,
                         separated by semi-colons and assigned with equals
                         signs.
+    -Z CIPHERS, --ciphers=CIPHERS
+                        Openssl SSL/TLS cipher name(s) to use for negotiation.  Passed
+                        directly to ab's -Z option.  ab-only.
     -c CONCURRENT, --concurrent=CONCURRENT
                         The number of concurrent connections to make to the
                         target (default: 100).

--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -441,6 +441,9 @@ def _attack(params):
         else:
             options += ' -C \"sessionid=NotARealSessionID\"'
 
+        if params['ciphers'] is not '':
+            options += ' -Z %s' % params['ciphers']
+
         if params['basic_auth'] is not '':
             options += ' -A %s' % params['basic_auth']
 
@@ -684,6 +687,7 @@ def attack(url, n, c, **options):
     contenttype = options.get('contenttype', '')
     csv_filename = options.get("csv_filename", '')
     cookies = options.get('cookies', '')
+    ciphers = options.get('ciphers', '')
     post_file = options.get('post_file', '')
     keep_alive = options.get('keep_alive', False)
     basic_auth = options.get('basic_auth', '')
@@ -750,6 +754,7 @@ def attack(url, n, c, **options):
             'headers': headers,
             'contenttype': contenttype,
             'cookies': cookies,
+            'ciphers': ciphers,
             'post_file': options.get('post_file'),
             'keep_alive': options.get('keep_alive'),
             'mime_type': options.get('mime_type', ''),

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -120,6 +120,9 @@ commands:
     attack_group.add_option('-H', '--headers', metavar="HEADERS", nargs=1,
                             action='store', dest='headers', type='string', default='',
                             help="HTTP headers to send to the target to attack. Multiple headers should be separated by semi-colons, e.g header1:value1;header2:value2")
+    attack_group.add_option('-Z', '--ciphers', metavar="CIPHERS", nargs=1,
+                            action='store', dest='ciphers', type='string', default='',
+                            help="Openssl SSL/TLS cipher name(s) to use for negotiation.  Passed directly to ab's -Z option.  ab-only.")
     attack_group.add_option('-e', '--csv', metavar="FILENAME", nargs=1,
                             action='store', dest='csv_filename', type='string', default='',
                             help="Store the distribution of results in a csv file for all completed bees (default: '').")
@@ -224,6 +227,7 @@ commands:
             options.url += '/'
         additional_options = dict(
             cookies=options.cookies,
+            ciphers=options.ciphers,
             headers=options.headers,
             post_file=options.post_file,
             keep_alive=options.keep_alive,


### PR DESCRIPTION
Adds cipher suite option for newsapps/beeswithmachineguns #191, allowing specification of openssl cipher suite names with -Z, passed to Apachebench -Z option.  Apachebench-only currently, hurl may or may not offer a similar option