### PR TITLE
Reduce BWMG Instance SSH data

### DIFF
--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -445,7 +445,7 @@ def _attack(params):
             options += ' -A %s' % params['basic_auth']
 
         params['options'] = options
-    	# substrings to use for fgrep to perform remote output filtering
+        # substrings to use for fgrep to perform remote output filtering
         # resolves issue #194, too much data sent over SSH control channel to BWMG
         # any future statistics parsing that requires more output from ab
         # may need this line altered to include other patterns

--- a/beeswithmachineguns/bees.py
+++ b/beeswithmachineguns/bees.py
@@ -445,7 +445,12 @@ def _attack(params):
             options += ' -A %s' % params['basic_auth']
 
         params['options'] = options
-        benchmark_command = 'ab -v 3 -r -n %(num_requests)s -c %(concurrent_requests)s %(options)s "%(url)s"' % params
+    	# substrings to use for fgrep to perform remote output filtering
+        # resolves issue #194, too much data sent over SSH control channel to BWMG
+        # any future statistics parsing that requires more output from ab
+        # may need this line altered to include other patterns
+        params['output_filter_patterns'] = '\n'.join(['Time per request:', 'Requests per second: ', 'Failed requests: ', 'Connect: ', 'Receive: ', 'Length: ', 'Exceptions: ', 'Complete requests: ', 'HTTP/1.1'])
+        benchmark_command = 'ab -v 3 -r -n %(num_requests)s -c %(concurrent_requests)s %(options)s "%(url)s" 2>/dev/null | fgrep -F "%(output_filter_patterns)s"' % params
         print(benchmark_command)
         stdin, stdout, stderr = client.exec_command(benchmark_command)
 


### PR DESCRIPTION
Resolves newsapps/beeswithmachineguns #194, pertaining to overload of data carried via SSH to Python BWMG, especially for HTTPS.  stderr disacarded in benchmark_command, and stdout filtered remotely with fast non-regexp fgrep.